### PR TITLE
Implement deep-sleep on ESP8266 and on STM32

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,0 +1,13 @@
+simulator-radio-drv/
+mbed-os/rtos/*
+mbed-os/features/cellular/
+mbed-os/features/FEATURE_CLIENT/*
+mbed-os/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/
+mbed-os/features/FEATURE_UVISOR/*
+mbed-os/features/frameworks/*
+mbed-os/features/filesystem/*
+mbed-os/features/net/*
+mbed-os/features/netsocket/*
+mbed-os/features/nvstore/*
+mbed-os/features/storage/*
+node_modules/*

--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -32,7 +32,7 @@ void ESP8266::AddChar(char * s, char c) {
 void ESP8266::itoa(int n, char * s) {
     char k = 0;
     char r[11];
-    
+
     if(n == 0) {
         s[0] = '0';
         s[1] = 0;
@@ -69,7 +69,7 @@ bool ESP8266::RcvReply(char * r, int to) {
     Timer t;
     bool ended = 0;
     char c;
-    
+
     strcpy(r, "");
     t.start();
     while(!ended) {
@@ -185,12 +185,12 @@ void ESP8266::startTCPConn(char *IP, int port){
 
 void ESP8266::sendURL(char *URL, char *command){
     char url[300], snd[300], http_cmd[300];
-    
+
     strcpy(http_cmd, HTTPCMD);
-    
+
     strcat(http_cmd, URL);
     strcat(http_cmd, protocol);
-    
+
     strcpy(url, http_cmd);
     sprintf(snd,"AT+CIPSENDEX=%d",strlen(url));
     strcpy(command, url);
@@ -198,5 +198,9 @@ void ESP8266::sendURL(char *URL, char *command){
     wait(3);
     SendCMD(url);
 }
-    
-    
+
+void ESP8266::DeepSleep() {
+    char *cmd = "AT+GSLP=1";
+    SendCMD(cmd);
+}
+

--- a/ESP8266/ESP8266.h
+++ b/ESP8266/ESP8266.h
@@ -37,6 +37,10 @@ void CloseServerMode(void);
 void setTransparent(void);
 void startTCPConn(char * IP, int port);
 void sendURL(char *URL, char *command);
+/**
+ * Turn the ESP8266 into deep sleep
+ */
+void DeepSleep();
 
 private:
 Serial comm;
@@ -45,7 +49,7 @@ void AddChar(char * s, char c);
 void itoa(int c, char s[]);
 
 };
-  
+
 #endif
 /*
     COMMAND TABLE
@@ -56,7 +60,7 @@ void itoa(int c, char s[]);
     AT+CWMODE: define wifi mode; AT+CWMODE=<mode> 1= Sta, 2= AP, 3=both; Inquiry: AT+CWMODE? or AT+CWMODE=?
     AT+CWJAP: join the AP wifi; AT+ CWJAP =<ssid>,< pwd > - ssid = ssid, pwd = wifi password, both between quotes; Inquiry: AT+ CWJAP?
     AT+CWLAP: list the AP wifi
-    AT+CWQAP: quit the AP wifi; Inquiry: AT+CWQAP=?  
+    AT+CWQAP: quit the AP wifi; Inquiry: AT+CWQAP=?
     * AT+CWSAP: set the parameters of AP; AT+CWSAP= <ssid>,<pwd>,<chl>,<ecn> - ssid, pwd, chl = channel, ecn = encryption; Inquiry: AT+CWJAP?
     TCP/IP:
     AT+CIPSTATUS: get the connection status

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include "SDFileSystem.h"
 #include  "FATFileSystem.h"
 #include "DS3231.h"
+#include "stm32_standby.h"
 #include <stdio.h>
 
 SDFileSystem sd(D11, D12, D13, D10, "sd");
@@ -12,9 +13,10 @@ Serial pc(USBTX, USBRX);
 DS3231 rtc(D14,D15);
 FILE *fp;                                   // File pointer declear
 
+DigitalOut esp8266_reset(D7, 1);
 
 //wifi UART port and baud rate
-ESP8266 wifi(D8, D2, 115200); 
+ESP8266 wifi(D8, D2, 115200);
 
 //buffers for wifi library
 char resp[1000];
@@ -23,77 +25,101 @@ int dw,d,M,y,h,m,s;  //VARIABLES FOR TIME AND YEAR
 int timeout = 8000; //timeout for wifi commands
 
 //SSID and password for connection
-#define SSID "jared" 
-#define PASS "qwerty12hja"  
+#define SSID "Jan iPhone"
+#define PASS "mbedcloud"
 
  //Remote IP
 #define IP "184.106.153.149"
 
 //global variable
-long distance; 
+long distance;
 
 //Update key for thingspeak
-char* Update_Key = "MWE9AS4N7CBG2B92";
- 
+const char* Update_Key = "JNP1LEUBKU74MCJ0";
+
+bool check_if_connected(char *resp) {
+    return strstr(resp, "WIFI GOT IP") != NULL;
+}
+
+void wifi_after_connected();
+
 //Wifi init function
 void wifi_initialize(void){
-    
+
     pc.printf("******** Resetting wifi module ********\r\n");
     wifi.Reset();
-    
+
     //wait for 5 seconds for response, else display no response receiveed
-    if (wifi.RcvReply(resp, 5000))    
-        pc.printf("%s",resp);    
-    else
+    if (wifi.RcvReply(resp, 5000)) {
+        // pc.printf("%s",resp);
+    }
+    else {
         pc.printf("No response");
-    
+    }
+
+    if (check_if_connected(resp)) {
+        pc.printf("Connected\r\n");
+        wifi_after_connected();
+        return;
+    }
+
     pc.printf("******** Setting Station mode of wifi with AP ********\r\n");
     wifi.SetMode(1);    // set transparent  mode
     if (wifi.RcvReply(resp, timeout))    //receive a response from ESP
         pc.printf("%s",resp);    //Print the response onscreen
     else
         pc.printf("No response while setting mode. \r\n");
-    
+
+    if (check_if_connected(resp)) {
+        pc.printf("Connected\r\n");
+        wifi_after_connected();
+        return;
+    }
+
     pc.printf("******** Joining network with SSID and PASS ********\r\n");
-    wifi.Join(SSID, PASS);     
-    if (wifi.RcvReply(resp, timeout))    
-        pc.printf("%s",resp);   
+    wifi.Join(SSID, PASS);
+    if (wifi.RcvReply(resp, timeout))
+        pc.printf("%s",resp);
     else
         pc.printf("No response while connecting to network \r\n");
-        
-    pc.printf("******** Getting IP and MAC of module ********\r\n");
-    wifi.GetIP(resp);     
-    if (wifi.RcvReply(resp, timeout))    
-        pc.printf("%s",resp);    
-    else
-        pc.printf("No response while getting IP \r\n");
-    
+
+    wifi_after_connected();
+}
+
+void wifi_after_connected() {
+    // pc.printf("******** Getting IP and MAC of module ********\r\n");
+    // wifi.GetIP(resp);
+    // if (wifi.RcvReply(resp, timeout))
+    //     pc.printf("%s",resp);
+    // else
+    //     pc.printf("No response while getting IP \r\n");
+
     pc.printf("******** Setting WIFI UART passthrough ********\r\n");
-    wifi.setTransparent();          
-    if (wifi.RcvReply(resp, timeout))    
-        pc.printf("%s",resp);    
+    wifi.setTransparent();
+    if (wifi.RcvReply(resp, timeout))
+        pc.printf("%s",resp);
     else
         pc.printf("No response while setting wifi passthrough. \r\n");
-    wait(1);    
-    
+    wait(1);
+
     pc.printf("******** Setting single connection mode ********\r\n");
-    wifi.SetSingle();             
+    wifi.SetSingle();
     wifi.RcvReply(resp, timeout);
-    if (wifi.RcvReply(resp, timeout))    
-        pc.printf("%s",resp);    
+    if (wifi.RcvReply(resp, timeout))
+        pc.printf("%s",resp);
     else
         pc.printf("No response while setting single connection \r\n");
     wait(1);
 }
 
-void wifi_send(){
- 
+void wifi_send() {
+
  // HERE IS THE CODE FOR OBTAINING TIME FROM THE DS3231
-   
-   
+
+
  //END OF CODE USED FOR OBTAINING TIME
     sensor.start();
-    wait_ms(100); 
+    wait_ms(100);
     long distance=sensor.get_dist_cm();
      printf("distance is %dcm\n", distance);
      wait(1);
@@ -101,13 +127,13 @@ void wifi_send(){
        fp = fopen("/sd/mylogger.txt", "a");            // File open for "a"ppend
     if (fp == NULL) {                               // Error!
             pc.printf("Unable to write the file\r\n");
-        } 
+        }
     else {
     rtc.readDateTime(&dw,&d,&M,&y,&h,&m,&s);
     pc.printf("%02d/%02d/%4d\n",d,M,y);
     pc.printf("%02d:%02d:%02d",h,m,s);
     pc.printf(",");
-    
+
     fprintf(fp, "%02d/%02d/%4d\n",d,M,y);
     fprintf(fp, ",");
     fprintf(fp, "%02d:%02d:%02d",h,m,s);
@@ -118,43 +144,62 @@ void wifi_send(){
     fclose(fp);                                     // Cloce file.
     pc.printf("File successfully written!\r\n");    // Serial monitor.
 
-        
+
         wait(2);
-    
-    
+
+
     pc.printf("******** Starting TCP connection on IP and port ********\r\n");
     wifi.startTCPConn(IP,80);    //cipstart
     wifi.RcvReply(resp, timeout);
-    if (wifi.RcvReply(resp, timeout))    
-        pc.printf("%s",resp);    
+    if (wifi.RcvReply(resp, timeout))
+        pc.printf("%s",resp);
     else
         pc.printf("No response while starting TCP connection \r\n");
     wait(0.25);
-    
-    //create link 
-    sprintf(http_cmd,"/update?api_key=%s&field1=%d",Update_Key,distance); 
+
+    //create link
+    sprintf(http_cmd,"/update?api_key=%s&field1=%d",Update_Key,distance);
     pc.printf(http_cmd);
-    
+
     pc.printf("******** Sending URL to wifi ********\r\n");
     wifi.sendURL(http_cmd, comm);   //cipsend and get command
-    
 }
 
 void update_ThingSpeak()
 {
         wifi_send();
         wait(0.25);
-    
-    }
-    //to be called when wifi fails to initialize
-void use_sdCard(){
-    
-    }
-    int main() {
+}
+
+//to be called when wifi fails to initialize
+void use_sdCard() {
+
+}
+
+int main() {
+    set_time(0);
+
     pc.baud(115200);
+
+    pc.printf("******** MCU Woke Up ********\r\n");
+
+    esp8266_reset = 0;
+    wait_ms(20);
+    esp8266_reset = 1;
+
+    pc.printf("******** ESP8266 Woke Up ********\r\n");
+
     wifi_initialize();
-   while (1)
-    update_ThingSpeak();
-     wait(2);
+
+    while (1) {
+        wifi_send();
+
+        pc.printf("******** Done sending, putting to sleep ********\r\n");
+        wifi.DeepSleep();
+
+        pc.printf("******** ESP8266 is sleeping, putting MCU to sleep ********\r\n");
+
+        standby(10);
+    }
 
 }

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/mbed-os/#367dbdf5145f4d6aa3e483c147fe7bda1ce23a36

--- a/mbed.dlb
+++ b/mbed.dlb
@@ -1,1 +1,0 @@
-http://mbed.org/users/mbed_official/code/mbed/builds/e7ca05fa8600

--- a/stm32-standby-rtc-wakeup.lib
+++ b/stm32-standby-rtc-wakeup.lib
@@ -1,0 +1,1 @@
+https://github.com/janjongboom/stm32-standby-rtc-wakeup/#fd5b51fed1f2935448a65456a88a81171e8f19ea


### PR DESCRIPTION
This adds deep-sleep capabilities to both ESP8266 and the main MCU. Should drastically save on battery life. You can set the sleep time in the `standby()` line. Note that this is in seconds.

Change in circuitry:

* The pin that went to VDD now needs to go to D7.

Other changes required:

* Cut the LED from the ESP8266 to save power.
* Cut resistor R32 on the Nucleo board to save power.
* Cut the STLink interface off from the Nucleo board and power through Vin/GND.

Things to consider:

* There's an active I2C bus on D14/D15. You probably need to unload this by calling `AnalogIn dummy(A14)` (same for A15) to remove any internal pullups. But better test this before blindly doing it. An ammeter would be useful.
* Remove the interrupt on D4/D3, for same reason as above. Holding an interrupt requires internal pullup which draws power.